### PR TITLE
Move geometry update call to avoid error in geometry update check.

### DIFF
--- a/src/TwoPhaseFlowSimulation/TwoPhaseFlowSimulationModule.cc
+++ b/src/TwoPhaseFlowSimulation/TwoPhaseFlowSimulationModule.cc
@@ -314,9 +314,9 @@ _initGroup()
     auto groupCreator(options() -> groupCreator()) ;
     groupCreator -> init() ;
     groupCreator -> prepare() ;
-    groupCreator -> apply() ;
     // Group creation add new Geometry properties: need to update GeometryMng
     _updateGeometry();
+    groupCreator -> apply() ;
 }
 
 /*---------------------------------------------------------------------------*/


### PR DESCRIPTION
Fix in PR#12 was not covering all test cases.