### PR TITLE
correctly catch fatal errors and rethrow

### DIFF
--- a/common/ArcGeoSim/src/ArcGeoSim/Numerics/ShArcTools/LinearAlgebra/LinearSystem/LinearSystem.cc
+++ b/common/ArcGeoSim/src/ArcGeoSim/Numerics/ShArcTools/LinearAlgebra/LinearSystem/LinearSystem.cc
@@ -121,6 +121,10 @@ solve(Alien::ILinearSolver* solver)
     else
       return false;
   }
+  catch(Arccore::FatalErrorException& e)
+  {
+    throw e;
+  }
   catch(...)
   {
     return false;


### PR DESCRIPTION
Without this fix fatal errors in Alien are confused with linear solver non convergence.