### PR TITLE
Fix ubuntu tests fails

### DIFF
--- a/common/ArcaneInfra/bin/ArcaneTest.sh
+++ b/common/ArcaneInfra/bin/ArcaneTest.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 function check_parameters {
     echo "Check parameters:"


### PR DESCRIPTION
/bin/sh is not bash on ubuntu system