### PR TITLE
Ouranos integration

### DIFF
--- a/src/ExaDiBench/ExaDiBenchModule.cc
+++ b/src/ExaDiBench/ExaDiBenchModule.cc
@@ -138,6 +138,8 @@ init()
 
   Real3 center = centerCompute();
   center = subDomain()->parallelMng()->reduce(Parallel::ReduceSum,center);
+  Integer nb_cells_global = subDomain()->parallelMng()->reduce(Parallel::ReduceSum, ownCells().size());
+  center = center / nb_cells_global;
   pinfo() << "Initial Total center =  " << center[0] << " " << center[1] << " " << center[2];
 
   ENUMERATE_CELL(icell,allCells()) {
@@ -197,6 +199,8 @@ compute()
   pinfo() << "Total measure : volume = " << volume << ", area = " << area;
   Real3 center = centerCompute();
   center = subDomain()->parallelMng()->reduce(Parallel::ReduceSum,center);
+  Integer nb_cells_global = subDomain()->parallelMng()->reduce(Parallel::ReduceSum, ownCells().size());
+  center = center / nb_cells_global;
   pinfo() << "Total center = " << center[0] << " " << center[1] << " " << center[2];
 }
 
@@ -277,7 +281,7 @@ centerCompute()
     center += lcenter;
   }
 
-  return center/ownCells().size();
+  return center;
 }
 
 

--- a/src/ExaDiBench/MeshbReader/MeshbMeshReaderService.cc
+++ b/src/ExaDiBench/MeshbReader/MeshbMeshReaderService.cc
@@ -5,13 +5,54 @@
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 // -*- C++ -*-
+#include <arcane/ArcaneVersion.h>
+#include <arcane/utils/ArcanePrecomp.h>
 
-#include "arcane/BasicService.h"
-#include "arcane/IMeshReader.h"
-#include "arcane/FactoryService.h"
+#include <arcane/utils/Iostream.h>
+#include <arcane/utils/StdHeader.h>
+#include <arcane/utils/HashTableMap.h>
+#include <arcane/utils/ValueConvert.h>
+#include <arcane/utils/ScopedPtr.h>
+#include <arcane/utils/ITraceMng.h>
+#include <arcane/utils/String.h>
+#include <arcane/utils/StringBuilder.h>
+#include <arcane/utils/IOException.h>
+#include <arcane/utils/Collection.h>
+#include <arcane/utils/Enumerator.h>
+#include <arcane/utils/OStringStream.h>
+#include <arcane/ArcaneVersion.h>
+#include <arcane/FactoryService.h>
+#include <arcane/IMeshReader.h>
+#include <arcane/ISubDomain.h>
+#include <arcane/IMeshSubMeshTransition.h>
+#include <arcane/IItemFamily.h>
+#include <arcane/Item.h>
+#include <arcane/ItemEnumerator.h>
+#include <arcane/VariableTypes.h>
+#include <arcane/IParallelMng.h>
 
+#include <arcane/IIOMng.h>
+#include <arcane/IXmlDocumentHolder.h>
+#include <arcane/XmlNodeList.h>
+#include <arcane/XmlNode.h>
+
+#include <arcane/IMeshUtilities.h>
+#include <arcane/IMeshWriter.h>
+#include <arcane/BasicService.h>
+
+#include "arcane/utils/PlatformUtils.h"
+#include "arcane/utils/Convert.h"
+#include "arcane/utils/NotImplementedException.h"
+
+#include <arcane/utils/UserDataList.h>
+#include <arcane/utils/IUserData.h>
+#include <arcane/utils/AutoDestroyUserData.h>
+
+#include "ArcGeoSim/Utils/Utils.h"
 #include "ouranos/config.h"
 #include "ouranos/kernel/info.hpp"
+#include "ouranos/mesh/mesh.hpp"
+#include "ouranos/kernel/ouranos.hpp"
 
 using namespace Arcane;
 
@@ -28,12 +69,12 @@ virtual IMeshReader::eReturnType readMeshFromFile(IPrimaryMesh* mesh,
                                      const String& file_name,
                                      const String& dir_name,
                                      bool use_internal_partition);
+
 };
 
 MeshbMeshReader::MeshbMeshReader(const ServiceBuildInfo& sbi)
 : Arcane::BasicService(sbi)
 {
-
 }
 
 bool MeshbMeshReader::allowExtension(const String& str)
@@ -54,14 +95,72 @@ readMeshFromFile(IPrimaryMesh* mesh,
   info() << "=== READING Meshb MESH ===";
 
   info () << "Testing ouranos linking " << Ouranos::Kernel::version();
+  auto rns = std::make_shared<Ouranos::Kernel::Ouranos>();
+  Ouranos::Mesh::Mesh<3, Ouranos::Kernel::Block> msh(rns);
+  msh.read(file_name.localstr());
 
-  fatal() << "Meshb Reader not yet implemented";
+  const auto& vertices = msh.ver();
+  Integer nb_nodes = vertices.nbr();
 
-  // auto rns = std::make_shared<Ouranos::Kernel::Ouranos>(com());
-  // Ouranos::Mesh::Mesh<3, Ouranos::Kernel::Block> msh(rns);
-  // msh.read(file_name.c_str());
+  info() << "Ouranos version: " << Ouranos::Kernel::version();
+  info() << "Mesh read: " << nb_nodes << " nodes, "
+         << msh.tet().nbr() << " tetrahedra, "
+         << msh.tri().nbr() << " triangles";
+
+  // Arcane mesh
+  mesh->setDimension(3);
+
+  // Get tetra and triangles
+  const auto& tets = msh.tet();
+  Integer nb_tets = tets.nbr();
+  const auto& tris = msh.tri();
+  Integer nb_tris = tris.nbr();
+
+  // Build cells_infos array
+  SharedArray<Int64> cells_infos;
+  cells_infos.reserve(nb_tets * 6 + nb_tris * 5);
+
+  // Adding tetra
+  for (Integer i = 0; i < nb_tets; ++i) {
+      cells_infos.add(IT_Tetraedron4);
+      cells_infos.add(i);
+      for (Integer j = 0; j < 4; ++j) {
+          cells_infos.add(tets.con()[i + 1][j]);
+      }
+  }
+
+  // Adding triangles
+  for (Integer i = 0; i < nb_tris; ++i) {
+      cells_infos.add(IT_Triangle3);
+      cells_infos.add(nb_tets + i);
+      for (Integer j = 0; j < 3; ++j) {
+          cells_infos.add(tris.con()[i + 1][j]);
+      }
+  }
+
+  // Allocate cells
+  mesh->allocateCells(nb_tets + nb_tris, cells_infos, false);
+  mesh->endAllocate();
+
+  info() << "Arcane mesh created: " << mesh->nbNode() << " nodes, "
+         << mesh->nbCell() << " cells";
+
+  // Assign coords to nodes
+  const auto& coords = vertices.crd();
+  VariableNodeReal3& nodes_coord = mesh->nodesCoordinates();
+
+  ENUMERATE_NODE (inode, mesh->allNodes()) {
+      const Node& node = *inode;
+      Int64 uid = node.uniqueId().asInt64();
+      rns_real_t x = coords[uid - 1][0];
+      rns_real_t y = coords[uid - 1][1];
+      rns_real_t z = coords[uid - 1][2];
+      nodes_coord[inode] = Real3(x, y, z);
+  }
+  
   // auto refined_msh = Ouranos::Mesh::refine(rns, msh);
 
+  fatal() << "Meshb Reader not yet implemented";
   return RTOk;
 };
 

--- a/src/ExaDiBench/MeshbReader/MeshbMeshReaderService.cc
+++ b/src/ExaDiBench/MeshbReader/MeshbMeshReaderService.cc
@@ -39,6 +39,7 @@
 #include <arcane/IMeshUtilities.h>
 #include <arcane/IMeshWriter.h>
 #include <arcane/BasicService.h>
+#include <arcane/ServiceBuilder.h>
 
 #include "arcane/utils/PlatformUtils.h"
 #include "arcane/utils/Convert.h"
@@ -104,21 +105,18 @@ readMeshFromFile(IPrimaryMesh* mesh,
 
   info() << "Ouranos version: " << Ouranos::Kernel::version();
   info() << "Mesh read: " << nb_nodes << " nodes, "
-         << msh.tet().nbr() << " tetrahedra, "
-         << msh.tri().nbr() << " triangles";
+         << msh.tet().nbr() << " tetrahedra " ;
 
   // Arcane mesh
   mesh->setDimension(3);
 
-  // Get tetra and triangles
+  // Get tetras
   const auto& tets = msh.tet();
   Integer nb_tets = tets.nbr();
-  const auto& tris = msh.tri();
-  Integer nb_tris = tris.nbr();
 
   // Build cells_infos array
   SharedArray<Int64> cells_infos;
-  cells_infos.reserve(nb_tets * 6 + nb_tris * 5);
+  cells_infos.reserve(nb_tets * 6);
 
   // Adding tetra
   for (Integer i = 0; i < nb_tets; ++i) {
@@ -127,19 +125,11 @@ readMeshFromFile(IPrimaryMesh* mesh,
       for (Integer j = 0; j < 4; ++j) {
           cells_infos.add(tets.con()[i + 1][j]);
       }
-  }
+   }
 
-  // Adding triangles
-  for (Integer i = 0; i < nb_tris; ++i) {
-      cells_infos.add(IT_Triangle3);
-      cells_infos.add(nb_tets + i);
-      for (Integer j = 0; j < 3; ++j) {
-          cells_infos.add(tris.con()[i + 1][j]);
-      }
-  }
 
   // Allocate cells
-  mesh->allocateCells(nb_tets + nb_tris, cells_infos, false);
+  mesh->allocateCells(nb_tets, cells_infos, false);
   mesh->endAllocate();
 
   info() << "Arcane mesh created: " << mesh->nbNode() << " nodes, "
@@ -152,15 +142,24 @@ readMeshFromFile(IPrimaryMesh* mesh,
   ENUMERATE_NODE (inode, mesh->allNodes()) {
       const Node& node = *inode;
       Int64 uid = node.uniqueId().asInt64();
-      rns_real_t x = coords[uid - 1][0];
-      rns_real_t y = coords[uid - 1][1];
-      rns_real_t z = coords[uid - 1][2];
+      rns_real_t x = coords[uid][0];
+      rns_real_t y = coords[uid][1];
+      rns_real_t z = coords[uid][2];
       nodes_coord[inode] = Real3(x, y, z);
   }
-  
+
+// Mesh into vtk for debug
+IMeshWriter* writer = Arcane::ServiceBuilder<IMeshWriter>::createInstance(
+    mesh->subDomain(), "VtkLegacyMeshWriter"
+);
+if (writer) {
+    writer->writeMeshToFile(mesh, file_name + ".vtk");
+    info() << "Mesh saved to " << file_name << ".vtk";
+} else {
+    info() << "Writer not found";
+}
   // auto refined_msh = Ouranos::Mesh::refine(rns, msh);
 
-  fatal() << "Meshb Reader not yet implemented";
   return RTOk;
 };
 

--- a/src/ExaDiBench/MeshbReader/MeshbMeshReaderService.cc
+++ b/src/ExaDiBench/MeshbReader/MeshbMeshReaderService.cc
@@ -57,6 +57,26 @@
 
 using namespace Arcane;
 
+// Add every elements from a specific types (tetra, hexa, ...) to cells_infos.
+template <typename ElementT>
+Integer appendBlockElements(
+    const ElementT& elts,
+    Int64 arcane_type,
+    Integer nb_nodes_per_elt,
+    SharedArray<Int64>& cells_infos,
+    Integer uid_offset)
+{
+  Integer nb = elts.nbr();
+  cells_infos.reserve(cells_infos.size() + nb * (nb_nodes_per_elt + 2));
+  for (Integer i = 0; i < nb; ++i) {
+    cells_infos.add(arcane_type);
+    cells_infos.add(uid_offset + i);
+    for (Integer j = 0; j < nb_nodes_per_elt; ++j)
+      cells_infos.add(elts.con()[i + 1][j]);
+  }
+  return nb;
+}
+
 class MeshbMeshReader
 : public BasicService
 , public IMeshReader
@@ -91,74 +111,188 @@ readMeshFromFile(IPrimaryMesh* mesh,
                  const String& dir_name,
                  bool use_internal_partition)
 {
+
   Arcane::Trace::Setter setter(traceMng(),"IXMMeshReader");
+ 
+  using metis_t = Ouranos::Mesh::Partitioning::Metis;
+  
 
-  info() << "=== READING Meshb MESH ===";
+  Integer sid = subDomain()->subDomainId();
+  IParallelMng* pm = subDomain()->parallelMng();
+  auto pcom = pm->communicator();
+  MPI_Comm mpi_com = (pcom.isValid())  ? static_cast<const MPI_Comm>(pcom) : MPI_COMM_WORLD;
+  
+  bool master = sid == 0 ;
+  
+  if (use_internal_partition)
+  {
+      Integer nb_cells = 0;
+      Integer dim = 0;
+      SharedArray<Int64> cells_infos;
+      SharedArray<Real3> node_coords_master;
 
-  info () << "Testing ouranos linking " << Ouranos::Kernel::version();
-  auto rns = std::make_shared<Ouranos::Kernel::Ouranos>();
-  Ouranos::Mesh::Mesh<3, Ouranos::Kernel::Block> msh(rns);
-  msh.read(file_name.localstr());
+      if (master)
+      {
+          info() << "=== READING Meshb MESH ===";
+          info() << "Testing ouranos linking " << Ouranos::Kernel::version();
+          MPI_Comm seq_com = MPI_COMM_SELF;
+          Ouranos::Kernel::MPI::Com com(seq_com);
+          auto rns = std::make_shared<Ouranos::Kernel::Ouranos>(com);
+          dim = Ouranos::Mesh::read_mesh_dimension(rns, file_name.localstr());
+          info() << "Mesh dimension : " << dim;
 
-  const auto& vertices = msh.ver();
-  Integer nb_nodes = vertices.nbr();
+          if (dim == 3)
+          {
+              Ouranos::Mesh::Mesh<3, Ouranos::Kernel::Block> msh(rns);
+              msh.read(file_name.localstr());
 
-  info() << "Ouranos version: " << Ouranos::Kernel::version();
-  info() << "Mesh read: " << nb_nodes << " nodes, "
-         << msh.tet().nbr() << " tetrahedra " ;
+              const auto& vertices = msh.ver();
+              Integer nb_nodes = vertices.nbr();
+              info() << "Mesh read: " << nb_nodes << " nodes";
 
-  // Arcane mesh
-  mesh->setDimension(3);
+              Integer uid_offset = 0;
+              Integer nb_tets = appendBlockElements(msh.tet(), IT_Tetraedron4, 4, cells_infos, uid_offset);
+              uid_offset += nb_tets;
+              Integer nb_hex = appendBlockElements(msh.hex(), IT_Hexaedron8, 8, cells_infos, uid_offset);
+              uid_offset += nb_hex;
+              nb_cells = uid_offset;
+              info() << "Mesh read: " << nb_tets << " tetrahedra, " << nb_hex << " hexahedra";
 
-  // Get tetras
-  const auto& tets = msh.tet();
-  Integer nb_tets = tets.nbr();
+              const auto& coords = vertices.crd();
+              node_coords_master.resize(nb_nodes + 1);
+              for (Integer i = 1; i <= nb_nodes; ++i)
+                  node_coords_master[i] = Real3(coords[i][0], coords[i][1], coords[i][2]);
+          }
+          else if (dim == 2)
+          {
+              Ouranos::Mesh::Mesh<2, Ouranos::Kernel::Block> msh(rns);
+              msh.read(file_name.localstr());
 
-  // Build cells_infos array
-  SharedArray<Int64> cells_infos;
-  cells_infos.reserve(nb_tets * 6);
+              const auto& vertices = msh.ver();
+              Integer nb_nodes = vertices.nbr();
+              info() << "Mesh read: " << nb_nodes << " nodes";
 
-  // Adding tetra
-  for (Integer i = 0; i < nb_tets; ++i) {
-      cells_infos.add(IT_Tetraedron4);
-      cells_infos.add(i);
-      for (Integer j = 0; j < 4; ++j) {
-          cells_infos.add(tets.con()[i + 1][j]);
+              Integer uid_offset = 0;
+              Integer nb_tri = appendBlockElements(msh.tri(), IT_Triangle3, 3, cells_infos, uid_offset);
+              uid_offset += nb_tri;
+              nb_cells = uid_offset;
+              info() << "Mesh read: " << nb_tri << " triangles";
+
+              const auto& coords = vertices.crd();
+              node_coords_master.resize(nb_nodes + 1);
+              for (Integer i = 1; i <= nb_nodes; ++i)
+                  node_coords_master[i] = Real3(coords[i][0], coords[i][1], 0.0);
+          }
+          else
+          {
+              fatal() << "Dimension " << dim << " not supported by Ouranos";
+          }
       }
-   }
 
+      pm->broadcast(ArrayView<Integer>(1, &dim), 0);
 
-  // Allocate cells
-  mesh->allocateCells(nb_tets, cells_infos, false);
-  mesh->endAllocate();
+      mesh->setDimension(dim);
+      mesh->allocateCells(nb_cells, cells_infos, false);
+      mesh->endAllocate();
 
-  info() << "Arcane mesh created: " << mesh->nbNode() << " nodes, "
-         << mesh->nbCell() << " cells";
-
-  // Assign coords to nodes
-  const auto& coords = vertices.crd();
-  VariableNodeReal3& nodes_coord = mesh->nodesCoordinates();
-
-  ENUMERATE_NODE (inode, mesh->allNodes()) {
-      const Node& node = *inode;
-      Int64 uid = node.uniqueId().asInt64();
-      rns_real_t x = coords[uid][0];
-      rns_real_t y = coords[uid][1];
-      rns_real_t z = coords[uid][2];
-      nodes_coord[inode] = Real3(x, y, z);
+      {
+          VariableNodeReal3& nodes_coord = mesh->nodesCoordinates();
+          ENUMERATE_NODE (inode, mesh->allNodes()) {
+              const Node& node = *inode;
+              Int64 uid = node.uniqueId().asInt64();
+              nodes_coord[inode] = node_coords_master[uid];
+          }
+      }
   }
+else
+{
+  // Every mpi process reads the mesh -> Ouranos read the mesh and partition all the data 
+  //Collective routine
+  info() << "Ouranos versions: " << Ouranos::Kernel::version();
 
-// Mesh into vtk for debug
-IMeshWriter* writer = Arcane::ServiceBuilder<IMeshWriter>::createInstance(
-    mesh->subDomain(), "VtkLegacyMeshWriter"
-);
-if (writer) {
-    writer->writeMeshToFile(mesh, file_name + ".vtk");
-    info() << "Mesh saved to " << file_name << ".vtk";
-} else {
-    info() << "Writer not found";
+  Ouranos::Kernel::MPI::Com com(mpi_com);
+  auto rns = std::make_shared<Ouranos::Kernel::Ouranos>(com);
+  int dim = Ouranos::Mesh::read_mesh_dimension(rns,file_name.localstr()) ;
+
+  switch(dim)
+  {
+    case 3:
+    {
+      Ouranos::Mesh::Mesh<3, Ouranos::Kernel::Block> msh(rns);
+      msh.read(file_name.localstr());
+      int nb_ghost_layer = 0 ; 
+      auto part_mesh = msh.to_part<metis_t>(nb_ghost_layer) ; 
+
+      auto& vertices = part_mesh.ver();
+      Integer nb_nodes = vertices.nbr();
+
+      info() << "Ouranos version: " << Ouranos::Kernel::version();
+      info() << "Mesh read: " << nb_nodes << " nodes, "
+            << part_mesh.tet().nbr() << " tetrahedra " ;
+
+      // Arcane mesh
+      mesh->setDimension(3);
+
+      // Get tetras
+      auto& tets = part_mesh.tet();
+      Integer nb_tets = tets.nbr();
+
+      //info() << "nb_tets local (with duplicated) = " << nb_tets;
+
+      auto vertex_part = vertices.location();
+      const auto& tet_gids = tets.location()->gid();
+
+      SharedArray<Int64> cells_infos;
+      cells_infos.reserve(nb_tets * 6);
+
+      for (Integer i = 0; i < nb_tets; ++i) {
+          cells_infos.add(IT_Tetraedron4);
+          cells_infos.add(tet_gids[i]);
+          for (Integer j = 0; j < 4; ++j) {
+              rns_int_t lid = tets.con()(i + 1)[j];
+              rns_int_t node_gid = vertex_part->lid_to_gid(lid);
+              cells_infos.add(node_gid);
+          }
+      }
+
+      mesh->setDimension(3);
+      mesh->allocateCells(nb_tets, cells_infos, false);
+      mesh->endAllocate();
+
+      auto& coords = vertices.crd();
+      VariableNodeReal3& nodes_coord = mesh->nodesCoordinates();
+
+      ENUMERATE_NODE (inode, mesh->allNodes()) {
+          const Node& node = *inode;
+          Int64 uid = node.uniqueId().asInt64();
+          nodes_coord[inode] = Real3(coords[uid][0], coords[uid][1], coords[uid][2]);
+      }
+    }
+    break ;
+    case 2:
+    {
+      fatal()<<"NOT YET IMPLEMENTED" ;
+    }
+    break ; 
+    default:
+    {
+      fatal()<<"Dimension" << dim << "not supported by Ouranos" ;
+    }
+  }
 }
-  // auto refined_msh = Ouranos::Mesh::refine(rns, msh);
+
+
+// // Mesh into vtk for debug
+// IMeshWriter* writer = Arcane::ServiceBuilder<IMeshWriter>::createInstance(
+//     mesh->subDomain(), "VtkLegacyMeshWriter"
+// );
+// if (writer) {
+//     writer->writeMeshToFile(mesh, file_name + ".vtk");
+//     info() << "Mesh saved to " << file_name << ".vtk";
+// } else {
+//     info() << "Writer not found";
+// }
+//   // auto refined_msh = Ouranos::Mesh::refine(rns, msh);
 
   return RTOk;
 };


### PR DESCRIPTION
# Add first working implementation of the Ouranos-based `.meshb` mesh reader
 
This PR provides a first functional implementation of `MeshbMeshReader`, allowing Arcane/Sharc to read `.meshb` mesh files through Ouranos
 
## What's done
 
- Read a `.meshb` file via Ouranos and populate an Arcane `IPrimaryMesh` with tetrahedra and node coordinates
- Temporary VTK export for debug — mesh integrity verified in ParaView

## Limitations
- Only a view check-up has been done, the mesh still may not be fully correct. 
- Sequential only
